### PR TITLE
feat: spotify and youtube added

### DIFF
--- a/src/app/admin/tracks/[tracksId]/(components)/TrackDetailsTap.tsx
+++ b/src/app/admin/tracks/[tracksId]/(components)/TrackDetailsTap.tsx
@@ -1,4 +1,4 @@
-import { Trackstype } from '@/modules/tracks/trackType'
+import { Trackstype } from '@/modules/tracks/trackType';
 
 const TrackDetailsTap = ({ tracks }: { tracks: Trackstype }) => {
   return (
@@ -12,11 +12,15 @@ const TrackDetailsTap = ({ tracks }: { tracks: Trackstype }) => {
         </div>
         <div className="grid grid-cols-2 md:grid-cols-none md:grid-rows-2">
           <div className="text-sm text-black">Artists</div>
-          <div className="text-base capitalize text-black">{tracks.artist.name}</div>
+          <div className="text-base capitalize text-black">
+            {tracks.artist.name}
+          </div>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-none md:grid-rows-2">
           <div className="text-sm text-black">Release</div>
-          <div className="text-base capitalize text-black">{tracks.release.title}</div>
+          <div className="text-base capitalize text-black">
+            {tracks.release.title}
+          </div>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-none md:grid-rows-2">
           <div className="text-sm text-black">Genres</div>
@@ -28,14 +32,25 @@ const TrackDetailsTap = ({ tracks }: { tracks: Trackstype }) => {
         </div>
         <div className="grid grid-cols-2 md:grid-cols-none md:grid-rows-2">
           <div className="text-sm text-black">Duration</div>
-          <div className="text-base capitalize text-black">{tracks.duration}</div>
+          <div className="text-base capitalize text-black">
+            {tracks.duration}
+          </div>
         </div>
-
+        <div className="grid grid-cols-2 md:grid-cols-none md:grid-rows-2">
+          <div className="text-sm text-black">Youtube</div>
+          <div className="text-base capitalize text-black">
+            {tracks.youtube}
+          </div>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-none md:grid-rows-2">
+          <div className="text-sm text-black">Spotify</div>
+          <div className="text-base capitalize text-black">
+            {tracks.spotify}
+          </div>
+        </div>
       </div>
-
-
     </div>
-  )
-}
+  );
+};
 
-export default TrackDetailsTap
+export default TrackDetailsTap;

--- a/src/app/admin/tracks/mutate/[[...tracksId]]/page.tsx
+++ b/src/app/admin/tracks/mutate/[[...tracksId]]/page.tsx
@@ -191,6 +191,8 @@ const Page = () => {
         : changeDurationToSchemaType('00:00:00'),
       slug: toMutatetrackData ? toMutatetrackData.slug : '',
       intro_track: toMutatetrackData ? null : null,
+      youtube: toMutatetrackData?.youtube || '',
+      spotify: toMutatetrackData?.spotify || '',
       artist: toMutatetrackData
         ? {
             value: toMutatetrackData.artist.id.toString(),
@@ -426,6 +428,36 @@ const Page = () => {
                 }}
                 name="release"
               ></Selector>
+            )}
+          </div>
+        </div>
+        <div className="flex gap-2 mb-2 max-sm:flex-col">
+          <div className="flex flex-col flex-1">
+            <TextField
+              id="youtube"
+              type="text"
+              label="Youtube "
+              className="flex-1"
+              {...formik.getFieldProps('youtube')}
+            />
+            {formik.errors.youtube && (
+              <div className="text-red-500 text-sm">
+                {formik.errors.youtube}
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col flex-1">
+            <TextField
+              id="spotify"
+              type="text"
+              label="Spotify "
+              className="flex-1"
+              {...formik.getFieldProps('spotify')}
+            />
+            {formik.errors.spotify && (
+              <div className="text-red-500 text-sm">
+                {formik.errors.spotify}
+              </div>
             )}
           </div>
         </div>

--- a/src/modules/tracks/trackType.ts
+++ b/src/modules/tracks/trackType.ts
@@ -18,6 +18,8 @@ export const trackSchema = z.object({
   title: z.string().pipe(nonempty),
   genres: z.array(selectorDataSchema).optional(),
   duration: durationSchema,
+  youtube: z.string().url({ message: 'Invalid URL format.' }),
+  spotify: z.string().url({ message: 'Invalid URL format.' }),
   intro_track: introTrackFile.optional().nullable(),
   release: selectorDataSchema,
 });
@@ -39,6 +41,8 @@ export type Trackstype = {
   title: string;
   slug: string;
   duration: string;
+  youtube: string;
+  spotify: string;
   intro_track: string;
   artist: ArtistType;
   release: ReleaseType;

--- a/src/modules/tracks/tracksApi.ts
+++ b/src/modules/tracks/tracksApi.ts
@@ -13,6 +13,8 @@ const tracksApi = baseApi.injectEndpoints({
         formData.append('id', String(payload.id));
         formData.append('title', String(payload.title));
         formData.append('slug', String(payload.slug));
+        formData.append('youtube', String(payload.youtube));
+        formData.append('spotify', String(payload.spotify));
         if (payload.intro_track)
           formData.append('intro_track', payload.intro_track);
         if (payload.duration)
@@ -129,6 +131,8 @@ const tracksApi = baseApi.injectEndpoints({
       query: ({ id, ...payload }) => {
         const formData = new FormData();
         formData.append('title', String(payload.title));
+        formData.append('youtube', String(payload.youtube));
+        formData.append('spotify', String(payload.spotify));
         formData.append('slug', String(payload.slug));
         if (payload.intro_track)
           formData.append('intro_track', payload.intro_track);


### PR DESCRIPTION
## Summary by Sourcery

Add support for YouTube and Spotify links in track details

New Features:
- Add YouTube and Spotify URL fields to track information
- Implement URL input fields for YouTube and Spotify links in track creation/editing form

Enhancements:
- Update track type definition to include YouTube and Spotify URL validation
- Modify track details view to display YouTube and Spotify links